### PR TITLE
feat: add connector count constraint

### DIFF
--- a/api/crud/crud.py
+++ b/api/crud/crud.py
@@ -1,10 +1,13 @@
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, joinedload
 from sqlalchemy.exc import IntegrityError
 from pydantic import UUID4
 from fastapi import HTTPException
 from ..models import models
 from ..schemas import schemas
-from ..utils.helpers import check_priority_constraint_connector, check_priority_constraint_station
+from ..utils.helpers import (check_priority_constraint_connector,
+                             check_priority_constraint_station,
+                             check_connector_count_connector,
+                             check_connector_count_station)
 
 
 def create_charging_station_type(db: Session, charging_station_type_data: schemas.ChargingStationTypeCreate):
@@ -81,13 +84,15 @@ def delete_charging_station_type(db: Session, charging_station_type_id: UUID4):
 
 
 def create_charging_station(db: Session, charging_station_data: schemas.ChargingStationCreate):
+    check_priority_constraint_station(db, charging_station_data.connectors)
+    check_connector_count_station(db, charging_station_data)
+
     try:
         db_charging_station = models.ChargingStation(**charging_station_data.dict(exclude={'connectors'}))
         db.add(db_charging_station)
         db.flush()
 
         connectors_data = charging_station_data.connectors
-        check_priority_constraint_station(db, connectors_data)
 
         for connector_data in connectors_data:
             connector = models.Connector(**connector_data.dict())
@@ -111,11 +116,28 @@ def get_charging_station(db: Session, charging_station_id: UUID4):
         .first()
     if not db_charging_station:
         raise HTTPException(status_code=404, detail="ChargingStation instance not found.")
+    if db_charging_station.type.plug_count != len(db_charging_station.connectors):
+        raise HTTPException(
+            status_code=400,
+            detail=f"This Charging Station has {len(db_charging_station.connectors)} "
+                   f"connectors instead of {db_charging_station.type.plug_count}."
+        )
     return db_charging_station
 
 
 def get_charging_station_list(db: Session, skip: int = 0, limit: int = 100):
-    return db.query(models.ChargingStation).offset(skip).limit(limit).all()
+    charging_stations = db.query(models.ChargingStation)\
+        .options(joinedload(models.ChargingStation.type),
+                 joinedload(models.ChargingStation.connectors))\
+        .offset(skip).limit(limit).all()
+    for station in charging_stations:
+        if len(station.connectors) != station.type.plug_count:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Charging station with id={station.id} has {len(station.connectors)} "
+                       f"connectors instead of {station.type.plug_count}."
+            )
+    return charging_stations
 
 
 def update_charging_station(
@@ -123,6 +145,9 @@ def update_charging_station(
         charging_station_id: UUID4,
         charging_station_data: schemas.ChargingStationCreate,
 ):
+    check_priority_constraint_station(db, charging_station_data.connectors)
+    check_connector_count_station(db, charging_station_data)
+
     try:
         db_charging_station = db.query(models.ChargingStation)\
             .filter(models.ChargingStation.id == charging_station_id)\
@@ -140,7 +165,6 @@ def update_charging_station(
             db.flush()
 
         connectors_data = charging_station_data.connectors
-        check_priority_constraint_station(db, connectors_data)
         for connector_data in connectors_data:
             connector = models.Connector(**connector_data.dict())
             db_charging_station.connectors.append(connector)
@@ -169,8 +193,10 @@ def delete_charging_station(db: Session, charging_station_id: UUID4):
 
 
 def create_connector(db: Session, connector_data: schemas.ConnectorCreate):
-    if "charging_station_id" in connector_data.dict() and connector_data.priority is True:
-        check_priority_constraint_connector(db, connector_data.charging_station_id)
+    if connector_data.dict().get('charging_station_id') is not None:
+        if connector_data.priority is True:
+            check_priority_constraint_connector(db, connector_data.charging_station_id)
+        check_connector_count_connector(db, connector_data.charging_station_id)
 
     try:
         db_connector = models.Connector(**connector_data.dict())
@@ -205,8 +231,10 @@ def update_connector(
         connector_id: UUID4,
         connector_data: schemas.ConnectorCreate,
 ):
-    if "charging_station_id" in connector_data.dict() and connector_data.priority is True:
-        check_priority_constraint_connector(db, connector_data.charging_station_id)
+    if connector_data.dict().get('charging_station_id') is not None:
+        if connector_data.priority is True:
+            check_priority_constraint_connector(db, connector_data.charging_station_id)
+        check_connector_count_connector(db, connector_data.charging_station_id)
 
     try:
         db_connector = db.query(models.Connector)\

--- a/api/utils/helpers.py
+++ b/api/utils/helpers.py
@@ -26,3 +26,35 @@ def check_priority_constraint_station(db: Session, connectors_data: List[schemas
             status_code=400,
             detail="Only one connector in each Charging Station can have priority."
         )
+
+
+def check_connector_count_connector(db: Session, charging_station_id: UUID4):
+    charging_station = db.query(models.ChargingStation)\
+        .filter(models.ChargingStation.id == charging_station_id)\
+        .join(models.ChargingStationType)\
+        .one_or_none()
+    if not charging_station:
+        raise HTTPException(status_code=404, detail="ChargingStation not found.")
+
+    current_connector_count = len(charging_station.connectors)
+    if current_connector_count >= charging_station.type.plug_count:
+        raise HTTPException(
+            status_code=400,
+            detail=f"The number of connectors cannot exceed {charging_station.type.plug_count} "
+                   f"in this Charging Station."
+        )
+
+
+def check_connector_count_station(db: Session, charging_station_data: schemas.ChargingStationCreate):
+    charging_station_type = db.query(models.ChargingStationType).\
+        filter(models.ChargingStationType.id == charging_station_data.type_id).\
+        one_or_none()
+    if not charging_station_type:
+        raise HTTPException(status_code=404, detail="ChargingStationType not found.")
+
+    connector_count = len(charging_station_data.connectors)
+    if connector_count != charging_station_type.plug_count:
+        raise HTTPException(
+            status_code=400,
+            detail=f"The number of connectors must equal {charging_station_type.plug_count} in this Charging Station."
+        )


### PR DESCRIPTION
Add helper methods for veryfing the amount of connectors in given Charging Station in relation to Charging Station Type's plug_count and implement them in crud.py. Additionally, disable reading Charging Stations when the connector count is inappropriate.