### PR TITLE
feat: add five charging station types on startup

### DIFF
--- a/api/database/base.py
+++ b/api/database/base.py
@@ -1,0 +1,4 @@
+from sqlalchemy.ext.declarative import declarative_base
+
+
+Base = declarative_base()

--- a/api/database/database.py
+++ b/api/database/database.py
@@ -1,6 +1,7 @@
 from sqlalchemy import create_engine
-from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import sessionmaker, Session
+from .base import Base
+from .seed import seed_charging_station_types
 import os
 from dotenv import load_dotenv
 
@@ -12,7 +13,12 @@ engine = create_engine(SQLALCHEMY_DATABASE_URL)
 
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
-Base = declarative_base()
+
+def init_db():
+    Base.metadata.create_all(bind=engine)
+
+    with Session(engine) as session:
+        seed_charging_station_types(session)
 
 
 def get_db():

--- a/api/database/seed.py
+++ b/api/database/seed.py
@@ -1,0 +1,21 @@
+from ..models.models import ChargingStationType
+
+
+default_charging_station_types = [
+    {'name': 'Type A', 'plug_count': 2, 'efficiency': 88.53, 'current_type': 'AC'},
+    {'name': 'Type B', 'plug_count': 2, 'efficiency': 87.57, 'current_type': 'DC'},
+    {'name': 'Type C', 'plug_count': 1, 'efficiency': 93.06, 'current_type': 'AC'},
+    {'name': 'Type D', 'plug_count': 3, 'efficiency': 83.14, 'current_type': 'DC'},
+    {'name': 'Type E', 'plug_count': 1, 'efficiency': 87.82, 'current_type': 'AC'}
+]
+
+
+def seed_charging_station_types(db_session):
+    existing_types = db_session.query(ChargingStationType).count()
+    if existing_types == 0:
+        types = [ChargingStationType(**data) for data in default_charging_station_types]
+        db_session.add_all(types)
+        db_session.commit()
+        print("Database has been seeded with initial charging station types.")
+    else:
+        print("Charging station types already exist. No changes made.")

--- a/api/main.py
+++ b/api/main.py
@@ -1,10 +1,17 @@
 from fastapi import FastAPI
+from .database.database import init_db
 from .routers import charging_station_type_router, charging_station_router, connector_router
 
 app = FastAPI(
     title="EVChargingStation",
     description="This API allows you to manage EV charging stations, their types and connectors."
 )
+
+
+@app.on_event("startup")
+def startup_event():
+    init_db()
+
 
 app.include_router(charging_station_type_router.router, tags=["Charging Station Types"])
 app.include_router(charging_station_router.router, tags=["Charging Stations"])

--- a/api/models/models.py
+++ b/api/models/models.py
@@ -3,7 +3,7 @@ from sqlalchemy.dialects.postgresql import UUID, INET
 from sqlalchemy.orm import relationship
 import uuid
 import enum
-from ..database.database import Base
+from ..database.base import Base
 
 
 class CurrentTypeEnum(enum.Enum):


### PR DESCRIPTION
Create five default charging station types and seed them on startup if there are no charging station types declared. Move Base to separate file to avoid circular imports.